### PR TITLE
Fix DDP over-subscribes cuda:0 with nproc_per_node processes

### DIFF
--- a/preflight/run.py
+++ b/preflight/run.py
@@ -1,4 +1,5 @@
 import sys, os
+import socket
 import torch
 import torch.distributed as dist
 import torch.nn as nn
@@ -18,12 +19,14 @@ def demo_basic():
     if sys.argv[1] == "ddp":
         dist.init_process_group("nccl")
         rank = dist.get_rank()
-        print(f"Start running basic DDP example on rank {rank}.")
+        hostname = socket.gethostname()
+        print(f"Start running basic DDP example on rank {hostname}:{rank}.")
         device_id = f"cuda:{rank % torch.cuda.device_count()}"
         print("Distributed training variables:")
         for env_key in ("LOCAL_RANK", "RANK", "GROUP_RANK", "LOCAL_WORLD_SIZE", "WORLD_SIZE"):
             print(f"{env_key}: {os.environ.get(env_key, '')}")
         print("#############")
+        torch.cuda.set_device(device_id)
         model = ToyModel().to(device_id)
         ddp_model = DDP(model, device_ids=[device_id])
     elif sys.argv[1] == "local":


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* There were `nproc_per_node` processes running on device `cuda:0`. This PR fixes this issue.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
